### PR TITLE
Fix: Revise fast mode scaling based on arXiv:2606.29129

### DIFF
--- a/src/oz2/common/template_math.hpp
+++ b/src/oz2/common/template_math.hpp
@@ -216,6 +216,10 @@ template <> __device__ __forceinline__ cuDoubleComplex Tcast<char2, cuDoubleComp
 template <> __device__ __forceinline__ cuDoubleComplex Tcast<short2, cuDoubleComplex>(short2 in) { return cuDoubleComplex{double(in.x), double(in.y)}; }
 template <> __device__ __forceinline__ double Tcast<uint8_t, double>(uint8_t in) { return double(in); }
 
+template <typename Tin> __device__ __forceinline__ float float_ru(Tin in);
+template <> __device__ __forceinline__ float float_ru<double>(double in) { return __double2float_ru(in); };
+template <> __device__ __forceinline__ float float_ru<float>(float in) { return in; };
+
 //------------------------------
 // static_cast (fp -> int)
 //------------------------------

--- a/src/oz2/scaling/fast/calc_sft.hpp
+++ b/src/oz2/scaling/fast/calc_sft.hpp
@@ -6,27 +6,18 @@
 
 namespace gemmul8::scaling::fast {
 
-inline constexpr float h4u_ru = 0x1.0000060000000p-1F; // round_up(0.5 / (1 - 4 * 2^-24))
+inline constexpr float u2 = 0x1.0000000000000p-23F; // 2^-23
 
-template <Backend BACKEND, unsigned NUM_MODULI>
-__device__ __forceinline__ int32_t calc_sft(double amax, double vecnrm) {
-    if (amax == 0.0) return 0;
-    const int32_t exponent = common::Tilogb<double>(vecnrm);
-    const float vecnrmf    = __double2float_ru(scalbn(vecnrm, -exponent));
-    const float log2vnrm   = __fadd_ru(__fmul_ru(h4u_ru, __log2f(vecnrmf)), exponent);
+template <Backend BACKEND, unsigned NUM_MODULI, typename T>
+__device__ __forceinline__ int32_t calc_sft(T vecnrm) {
+    if (vecnrm == T(0.0)) return 0;
+    const int32_t exponent = common::Tilogb<T>(vecnrm);
+    const float vecnrmf    = common::float_ru<T>(common::Tscalbn<T>(vecnrm, -exponent));
+    const float exponent2  = exponent * 0.5f;
     constexpr float log2P  = common::table::log2P<BACKEND, NUM_MODULI>;
-    const float exp1       = __fsub_rd(__fsub_rd(log2P, 2.0f), fmaxf(1.0f, log2vnrm));
-    return __float2int_rd(exp1) - common::Tilogb<double>(amax);
-}
-
-template <Backend BACKEND, unsigned NUM_MODULI>
-__device__ __forceinline__ int32_t calc_sft(float amax, float vecnrm) {
-    if (amax == 0.0f) return 0;
-    const float log2vsum  = __log2f(vecnrm);
-    const float log2vnrm  = __fmul_ru(h4u_ru, log2vsum);
-    constexpr float log2P = common::table::log2P<BACKEND, NUM_MODULI>;
-    const float exp1      = __fsub_rd(__fsub_rd(log2P, 2.0f), fmaxf(1.0f, log2vnrm));
-    return __float2int_rd(exp1) - common::Tilogb<float>(amax);
+    const float mu0        = __fsub_rd(log2P, exponent2);
+    const float mu1        = __fadd_ru(__log2f(vecnrmf) * 0.5f, u2);
+    return __float2int_rd(__fsub_rd(mu0, mu1));
 }
 
 template <typename T, Backend BACKEND, unsigned NUM_MODULI,
@@ -37,20 +28,17 @@ __global__ void calc_sft_rowwise(
     int16_t *const __restrict__ sftA //
 ) {
     using U = common::underlying_t<T>;
-    __shared__ U samax[common::TILE_DIM][common::TILE_DIM + 1];
     __shared__ U ssum[common::TILE_DIM][common::TILE_DIM + 1];
 
-    U sum;
-    U amax = find_amax_and_nrm_tile<T, UPLO, DIAG>(rows_A, cols_A, A, lda, samax, ssum, sum);
+    U sum = calc_nrm_tile<T, UPLO, DIAG>(rows_A, cols_A, A, lda, ssum);
     if constexpr (DIAG == CUBLAS_DIAG_UNIT) {
         constexpr U Uone = common::Tconst<U>::one();
         sum              = common::__Tadd_ru<U>(sum, Uone);
-        amax             = max(amax, Uone);
     }
 
     const unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.y;
     if (row_idx < rows_A && threadIdx.x == 0) {
-        const int32_t sft = calc_sft<BACKEND, NUM_MODULI>(amax, sum);
+        const int32_t sft = calc_sft<BACKEND, NUM_MODULI, U>(sum);
         sftA[row_idx]     = int16_t(-sft);
     }
 }
@@ -61,20 +49,17 @@ __device__ __forceinline__ int32_t calc_sft_colwise(
     const unsigned rows_A,
     const T *const __restrict__ in,
     int16_t *const __restrict__ sftA,
-    common::underlying_t<T> *samax,
     common::underlying_t<T> *ssum //
 ) {
     using U = common::underlying_t<T>;
 
-    U sum;
-    U amax = find_amax_and_nrm<T, UPLO, DIAG>(rows_A, in, samax, ssum, sum);
+    U sum = calc_nrm<T, UPLO, DIAG>(rows_A, in, ssum);
     if constexpr (DIAG == CUBLAS_DIAG_UNIT) {
         constexpr U Uone = common::Tconst<U>::one();
         sum              = common::__Tadd_ru<U>(sum, Uone);
-        amax             = max(amax, Uone);
     }
 
-    const int32_t sft = calc_sft<BACKEND, NUM_MODULI>(amax, sum);
+    const int32_t sft = calc_sft<BACKEND, NUM_MODULI, U>(sum);
     if (threadIdx.x == 0) {
         const unsigned col_idx = blockIdx.x;
         sftA[col_idx]          = int16_t(-sft);
@@ -87,22 +72,18 @@ template <typename T, cublasFillMode_t UPLO, bool HERM>
 __global__ void calc_stat_sym_rowwise(
     const unsigned n,
     const T *const __restrict__ A, const size_t lda,
-    common::underlying_t<T> *const __restrict__ amaxA,
     common::underlying_t<T> *const __restrict__ sumA //
 ) {
     using U = common::underlying_t<T>;
 
-    __shared__ U samax[common::TILE_DIM][common::TILE_DIM + 1];
     __shared__ U ssum[common::TILE_DIM][common::TILE_DIM + 1];
 
-    U sum;
-    const U amax = find_amax_and_nrm_tile<T, UPLO, CUBLAS_DIAG_NON_UNIT, HERM>(
-        n, n, A, lda, samax, ssum, sum);
+    const U sum = calc_nrm_tile<T, UPLO, CUBLAS_DIAG_NON_UNIT, HERM>(
+        n, n, A, lda, ssum);
 
     const unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.y;
     if (row_idx < n && threadIdx.x == 0) {
-        amaxA[row_idx] = amax;
-        sumA[row_idx]  = sum;
+        sumA[row_idx] = sum;
     }
 }
 
@@ -112,12 +93,10 @@ __global__ void calc_sft_sym_colwise(
     const unsigned n,
     const T *const __restrict__ A, const size_t lda,
     int16_t *const __restrict__ sftA,
-    common::underlying_t<T> *const __restrict__ amaxA,
     common::underlying_t<T> *const __restrict__ sumA //
 ) {
     using U = common::underlying_t<T>;
 
-    __shared__ U samax[32];
     __shared__ U ssum[32];
 
     const unsigned col_idx = blockIdx.x;
@@ -125,15 +104,12 @@ __global__ void calc_sft_sym_colwise(
 
     const T *const __restrict__ in = A + col_idx * lda;
 
-    U sum_col;
-    const U amax_col = find_amax_and_nrm<T, UPLO, CUBLAS_DIAG_UNIT>(
-        n, in, samax, ssum, sum_col);
+    const U sum_col = calc_nrm<T, UPLO, CUBLAS_DIAG_UNIT>(n, in, ssum);
 
     if (threadIdx.x == 0) {
-        const U amax_all = common::Tmax<U>(amaxA[col_idx], amax_col);
-        const U sum_all  = common::__Tadd_ru<U>(sumA[col_idx], sum_col);
+        const U sum_all = common::__Tadd_ru<U>(sumA[col_idx], sum_col);
 
-        const int32_t sft = calc_sft<BACKEND, NUM_MODULI>(amax_all, sum_all);
+        const int32_t sft = calc_sft<BACKEND, NUM_MODULI, U>(sum_all);
         sftA[col_idx]     = int16_t(-sft);
     }
 }
@@ -142,27 +118,23 @@ template <typename T, cublasFillMode_t UPLO, bool HERM>
 __global__ void calc_stat_sym_rowwise_partial(
     const unsigned n,
     const T *const __restrict__ A, const size_t lda,
-    common::underlying_t<T> *const __restrict__ partial_amax,
     common::underlying_t<T> *const __restrict__ partial_sum //
 ) {
     using U = common::underlying_t<T>;
 
-    __shared__ U samax[common::TILE_DIM][common::TILE_DIM + 1];
     __shared__ U ssum[common::TILE_DIM][common::TILE_DIM + 1];
 
     const unsigned col_begin = blockIdx.y * rowwise_sft_col_tile;
     const unsigned col_end   = min(n, col_begin + rowwise_sft_col_tile);
 
-    U sum;
-    const U amax = find_amax_and_nrm_tile_range<T, UPLO, CUBLAS_DIAG_NON_UNIT, HERM>(
-        n, n, A, lda, samax, ssum, sum, col_begin, col_end);
+    const U sum = calc_nrm_tile_range<T, UPLO, CUBLAS_DIAG_NON_UNIT, HERM>(
+        n, n, A, lda, ssum, col_begin, col_end);
 
     const unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.y;
 
     if (row_idx < n && threadIdx.x == 0) {
-        const size_t idx  = size_t(row_idx) * gridDim.y + blockIdx.y;
-        partial_amax[idx] = amax;
-        partial_sum[idx]  = sum;
+        const size_t idx = size_t(row_idx) * gridDim.y + blockIdx.y;
+        partial_sum[idx] = sum;
     }
 }
 
@@ -170,31 +142,25 @@ template <typename T>
 __global__ void calc_stat_sym_rowwise_reduce(
     const unsigned n,
     const unsigned num_col_blocks,
-    const common::underlying_t<T> *const __restrict__ partial_amax,
     const common::underlying_t<T> *const __restrict__ partial_sum,
-    common::underlying_t<T> *const __restrict__ amaxA,
     common::underlying_t<T> *const __restrict__ sumA //
 ) {
     using U = common::underlying_t<T>;
 
     const unsigned row_idx = blockIdx.x * blockDim.y + threadIdx.y;
 
-    U amax = common::Tconst<U>::zero();
-    U sum  = common::Tconst<U>::zero();
+    U sum = common::Tconst<U>::zero();
 
     if (row_idx < n) {
         for (unsigned cb = threadIdx.x; cb < num_col_blocks; cb += blockDim.x) {
             const size_t idx = size_t(row_idx) * num_col_blocks + cb;
-            amax             = max(amax, partial_amax[idx]);
             sum              = common::__Tadd_ru<U>(sum, partial_sum[idx]);
         }
 
-        amax = common::inner_warp_max<U>(amax);
-        sum  = common::inner_warp_sum<U>(sum);
+        sum = common::inner_warp_sum<U>(sum);
 
         if (threadIdx.x == 0) {
-            amaxA[row_idx] = amax;
-            sumA[row_idx]  = sum;
+            sumA[row_idx] = sum;
         }
     }
 }
@@ -204,9 +170,7 @@ inline void calc_stat_sym_rowwise_launch(
     const cudaStream_t stream,
     const unsigned n,
     const T *const A, const size_t lda,
-    common::underlying_t<T> *const partial_amax,
     common::underlying_t<T> *const partial_sum,
-    common::underlying_t<T> *const amaxA,
     common::underlying_t<T> *const sumA //
 ) {
     constexpr dim3 threads_findmax(threads_x_findmax_tile,
@@ -218,7 +182,7 @@ inline void calc_stat_sym_rowwise_launch(
 
         calc_stat_sym_rowwise<T, UPLO, HERM>
             <<<grid_findmax, threads_findmax, 0, stream>>>(
-                n, A, lda, amaxA, sumA);
+                n, A, lda, sumA);
         return;
     }
 
@@ -231,7 +195,7 @@ inline void calc_stat_sym_rowwise_launch(
 
     calc_stat_sym_rowwise_partial<T, UPLO, HERM>
         <<<grid_partial, threads_findmax, 0, stream>>>(
-            n, A, lda, partial_amax, partial_sum);
+            n, A, lda, partial_sum);
 
     constexpr dim3 threads_reduce(threads_x_rowwise_sft_reduce,
                                   threads_y_rowwise_sft_reduce);
@@ -241,34 +205,29 @@ inline void calc_stat_sym_rowwise_launch(
 
     calc_stat_sym_rowwise_reduce<T>
         <<<grid_reduce, threads_reduce, 0, stream>>>(
-            n, num_col_blocks,
-            partial_amax, partial_sum, amaxA, sumA);
+            n, num_col_blocks, partial_sum, sumA);
 }
 
 template <typename T, cublasFillMode_t UPLO, cublasDiagType_t DIAG>
 __global__ void calc_sft_rowwise_partial(
     const unsigned rows_A, const unsigned cols_A,
     const T *const __restrict__ A, const size_t lda,
-    common::underlying_t<T> *const __restrict__ partial_amax,
     common::underlying_t<T> *const __restrict__ partial_sum //
 ) {
     using U = common::underlying_t<T>;
 
-    __shared__ U samax[common::TILE_DIM][common::TILE_DIM + 1];
     __shared__ U ssum[common::TILE_DIM][common::TILE_DIM + 1];
 
     const unsigned col_begin = blockIdx.y * rowwise_sft_col_tile;
     const unsigned col_end   = min(cols_A, col_begin + rowwise_sft_col_tile);
 
-    U sum;
-    const U amax = find_amax_and_nrm_tile_range<T, UPLO, DIAG>(
-        rows_A, cols_A, A, lda, samax, ssum, sum, col_begin, col_end);
+    const U sum = calc_nrm_tile_range<T, UPLO, DIAG>(
+        rows_A, cols_A, A, lda, ssum, col_begin, col_end);
 
     const unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.y;
     if (row_idx < rows_A && threadIdx.x == 0) {
-        const size_t out  = size_t(row_idx) * gridDim.y + blockIdx.y;
-        partial_amax[out] = amax;
-        partial_sum[out]  = sum;
+        const size_t out = size_t(row_idx) * gridDim.y + blockIdx.y;
+        partial_sum[out] = sum;
     }
 }
 
@@ -276,7 +235,6 @@ template <typename T, Backend BACKEND, unsigned NUM_MODULI, cublasDiagType_t DIA
 __global__ void calc_sft_rowwise_reduce(
     const unsigned rows_A,
     const unsigned num_col_blocks,
-    const common::underlying_t<T> *const __restrict__ partial_amax,
     const common::underlying_t<T> *const __restrict__ partial_sum,
     int16_t *const __restrict__ sftA //
 ) {
@@ -284,27 +242,23 @@ __global__ void calc_sft_rowwise_reduce(
 
     const unsigned row_idx = blockIdx.x * blockDim.y + threadIdx.y;
 
-    U amax = common::Tconst<U>::zero();
-    U sum  = common::Tconst<U>::zero();
+    U sum = common::Tconst<U>::zero();
 
     if (row_idx < rows_A) {
         for (unsigned cb = threadIdx.x; cb < num_col_blocks; cb += blockDim.x) {
             const size_t idx = size_t(row_idx) * num_col_blocks + cb;
-            amax             = max(amax, partial_amax[idx]);
             sum              = common::__Tadd_ru<U>(sum, partial_sum[idx]);
         }
 
-        amax = common::inner_warp_max<U>(amax);
-        sum  = common::inner_warp_sum<U>(sum);
+        sum = common::inner_warp_sum<U>(sum);
 
         if constexpr (DIAG == CUBLAS_DIAG_UNIT) {
             constexpr U Uone = common::Tconst<U>::one();
             sum              = common::__Tadd_ru<U>(sum, Uone);
-            amax             = max(amax, Uone);
         }
 
         if (threadIdx.x == 0) {
-            const int32_t sft = calc_sft<BACKEND, NUM_MODULI>(amax, sum);
+            const int32_t sft = calc_sft<BACKEND, NUM_MODULI, U>(sum);
             sftA[row_idx]     = int16_t(-sft);
         }
     }
@@ -317,7 +271,6 @@ inline void calc_sft_rowwise_launch(
     const unsigned rows_A, const unsigned cols_A,
     const T *const A, const size_t lda,
     int16_t *const sftA,
-    common::underlying_t<T> *const partial_amax,
     common::underlying_t<T> *const partial_sum //
 ) {
     constexpr dim3 threads_findmax(threads_x_findmax_tile,
@@ -338,7 +291,7 @@ inline void calc_sft_rowwise_launch(
 
     calc_sft_rowwise_partial<T, UPLO, DIAG>
         <<<grid_partial, threads_findmax, 0, stream>>>(
-            rows_A, cols_A, A, lda, partial_amax, partial_sum);
+            rows_A, cols_A, A, lda, partial_sum);
 
     constexpr dim3 threads_reduce(threads_x_rowwise_sft_reduce,
                                   threads_y_rowwise_sft_reduce);
@@ -347,7 +300,7 @@ inline void calc_sft_rowwise_launch(
 
     calc_sft_rowwise_reduce<T, BACKEND, NUM_MODULI, DIAG>
         <<<grid_reduce, threads_reduce, 0, stream>>>(
-            rows_A, num_col_blocks, partial_amax, partial_sum, sftA);
+            rows_A, num_col_blocks, partial_sum, sftA);
 }
 
 } // namespace gemmul8::scaling::fast

--- a/src/oz2/scaling/fast/find_max.hpp
+++ b/src/oz2/scaling/fast/find_max.hpp
@@ -8,75 +8,62 @@ namespace gemmul8::scaling::fast {
 inline constexpr float UNIT_ROUNDOFF = 0x1.0000000000000p-24F;
 
 template <typename T>
-__device__ __forceinline__ void reduction_max_and_nrm(T amax, T sum, T *samax, T *ssum) {
-    amax = common::inner_warp_max(amax);
-    sum  = common::inner_warp_sum(sum);
+__device__ __forceinline__ T reduction_nrm(T sum, T *ssum) {
+    sum = common::inner_warp_sum(sum);
 
     if ((threadIdx.x & 31) == 0) {
-        samax[threadIdx.x >> 5] = amax;
-        ssum[threadIdx.x >> 5]  = sum;
+        ssum[threadIdx.x >> 5] = sum;
     }
     __syncthreads();
 
-    amax = common::Tconst<T>::zero();
-    sum  = common::Tconst<T>::zero();
+    sum = common::Tconst<T>::zero();
     if (threadIdx.x < 32) {
         if (threadIdx.x < (blockDim.x >> 5)) {
-            amax = samax[threadIdx.x];
-            sum  = ssum[threadIdx.x];
+            sum = ssum[threadIdx.x];
         }
-        amax = common::inner_warp_max(amax);
-        sum  = common::inner_warp_sum(sum);
+        sum = common::inner_warp_sum(sum);
         if (threadIdx.x == 0) {
-            samax[0] = amax;
-            ssum[0]  = sum;
+            ssum[0] = sum;
         }
     }
     __syncthreads();
+
+    return ssum[0];
 }
 
 template <typename T,
           cublasFillMode_t UPLO = CUBLAS_FILL_MODE_FULL,
           cublasDiagType_t DIAG = CUBLAS_DIAG_NON_UNIT>
-__device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm(
+__device__ __forceinline__ common::underlying_t<T> calc_nrm(
     const unsigned length,
     const T *const __restrict__ ptr,
-    common::underlying_t<T> *samax,
-    common::underlying_t<T> *ssum,
-    common::underlying_t<T> &vecnrm //
+    common::underlying_t<T> *ssum //
 ) {
     using U = common::underlying_t<T>;
-    U amax  = common::Tconst<U>::zero();
     U sum   = common::Tconst<U>::zero();
 
     const auto [begin, end] = general::column_load_range<UPLO, DIAG>(length);
     for (unsigned i = begin; i < end; i += blockDim.x) {
-        const T tmp = common::Tabs<T>(ptr[i]);
-        amax        = common::Tmax<T>(tmp, amax);
+        const T tmp = ptr[i];
         sum         = common::Tsqr_add_ru<T>(tmp, sum);
     }
 
-    reduction_max_and_nrm(amax, sum, samax, ssum);
-    vecnrm = ssum[0];
-    return samax[0];
+    return reduction_nrm(sum, ssum);
 }
 
 template <typename T,
           cublasFillMode_t UPLO = CUBLAS_FILL_MODE_FULL,
           cublasDiagType_t DIAG = CUBLAS_DIAG_NON_UNIT,
           bool HERM             = false>
-__device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile(
+__device__ __forceinline__ common::underlying_t<T> calc_nrm_tile(
     const unsigned m,
     const unsigned n,
     const T *const __restrict__ A,
     const size_t lda,
-    common::underlying_t<T> samax[][common::TILE_DIM + 1],
-    common::underlying_t<T> ssum[][common::TILE_DIM + 1],
-    common::underlying_t<T> &vecnrm //
+    common::underlying_t<T> ssum[][common::TILE_DIM + 1] //
 ) {
     using U          = common::underlying_t<T>;
     unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.x;
-    U amax           = common::Tconst<U>::zero();
     U sum            = common::Tconst<U>::zero();
 
     if (row_idx < m) {
@@ -91,16 +78,13 @@ __device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile(
 
             for (unsigned col = row_base + threadIdx.y; col < diag_end; col += blockDim.y) {
                 if (row_idx + unit <= col) {
-                    T val       = row_ptr[col * lda];
-                    val         = general::hemm_diag_value<HERM, T>(val, row_idx, col);
-                    const T tmp = common::Tabs<T>(val);
-                    amax        = common::Tmax<T>(tmp, amax);
-                    sum         = common::Tsqr_add_ru<T>(tmp, sum);
+                    T val = row_ptr[col * lda];
+                    val   = general::hemm_diag_value<HERM, T>(val, row_idx, col);
+                    sum   = common::Tsqr_add_ru<T>(val, sum);
                 }
             }
             for (unsigned col = full_begin + threadIdx.y; col < n; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
 
@@ -113,59 +97,49 @@ __device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile(
             const unsigned diag_end      = min(n, row_base + common::TILE_DIM);
 
             for (unsigned col = threadIdx.y; col < full_end; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
             for (unsigned col = full_end + threadIdx.y; col < diag_end; col += blockDim.y) {
                 if (col + unit <= row_idx) {
-                    T val       = row_ptr[col * lda];
-                    val         = general::hemm_diag_value<HERM, T>(val, row_idx, col);
-                    const T tmp = common::Tabs<T>(val);
-                    amax        = common::Tmax<T>(tmp, amax);
-                    sum         = common::Tsqr_add_ru<T>(tmp, sum);
+                    T val = row_ptr[col * lda];
+                    val   = general::hemm_diag_value<HERM, T>(val, row_idx, col);
+                    sum   = common::Tsqr_add_ru<T>(val, sum);
                 }
             }
 
         } else {
 
             for (unsigned col = threadIdx.y; col < n; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
         }
     }
 
-    samax[threadIdx.y][threadIdx.x] = amax;
-    ssum[threadIdx.y][threadIdx.x]  = sum;
+    ssum[threadIdx.y][threadIdx.x] = sum;
     __syncthreads();
 
-    sum    = ssum[threadIdx.x][threadIdx.y];
-    vecnrm = common::inner_warp_sum<U, common::TILE_DIM>(sum);
+    sum = ssum[threadIdx.x][threadIdx.y];
 
-    amax = samax[threadIdx.x][threadIdx.y];
-    return common::inner_warp_max<U, common::TILE_DIM>(amax);
+    return common::inner_warp_sum<U, common::TILE_DIM>(sum);
 }
 
 template <typename T,
           cublasFillMode_t UPLO = CUBLAS_FILL_MODE_FULL,
           cublasDiagType_t DIAG = CUBLAS_DIAG_NON_UNIT,
           bool HERM             = false>
-__device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile_range(
+__device__ __forceinline__ common::underlying_t<T> calc_nrm_tile_range(
     const unsigned m,
     const unsigned n,
     const T *const __restrict__ A,
     const size_t lda,
-    common::underlying_t<T> samax[][common::TILE_DIM + 1],
     common::underlying_t<T> ssum[][common::TILE_DIM + 1],
-    common::underlying_t<T> &vecnrm,
     const unsigned col_begin,
     const unsigned col_end_in //
 ) {
     using U          = common::underlying_t<T>;
     unsigned row_idx = blockIdx.x * common::TILE_DIM + threadIdx.x;
-    U amax           = common::Tconst<U>::zero();
     U sum            = common::Tconst<U>::zero();
 
     const unsigned col_end = min(n, col_end_in);
@@ -186,16 +160,13 @@ __device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile_range(
                 if (row_idx + unit <= col) {
                     T val       = row_ptr[col * lda];
                     val         = general::hemm_diag_value<HERM, T>(val, row_idx, col);
-                    const T tmp = common::Tabs<T>(val);
-                    amax        = common::Tmax<T>(tmp, amax);
-                    sum         = common::Tsqr_add_ru<T>(tmp, sum);
+                    sum         = common::Tsqr_add_ru<T>(val, sum);
                 }
             }
 
             const unsigned dense_begin = max(col_begin, full_begin);
             for (unsigned col = dense_begin + threadIdx.y; col < col_end; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
 
@@ -210,8 +181,7 @@ __device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile_range(
             const unsigned dense_begin = col_begin;
             const unsigned dense_end   = min(col_end, full_end);
             for (unsigned col = dense_begin + threadIdx.y; col < dense_end; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
 
@@ -221,31 +191,24 @@ __device__ __forceinline__ common::underlying_t<T> find_amax_and_nrm_tile_range(
                 if (col + unit <= row_idx) {
                     T val       = row_ptr[col * lda];
                     val         = general::hemm_diag_value<HERM, T>(val, row_idx, col);
-                    const T tmp = common::Tabs<T>(val);
-                    amax        = common::Tmax<T>(tmp, amax);
-                    sum         = common::Tsqr_add_ru<T>(tmp, sum);
+                    sum         = common::Tsqr_add_ru<T>(val, sum);
                 }
             }
 
         } else {
 
             for (unsigned col = col_begin + threadIdx.y; col < col_end; col += blockDim.y) {
-                const T tmp = common::Tabs<T>(row_ptr[col * lda]);
-                amax        = common::Tmax<T>(tmp, amax);
+                const T tmp = row_ptr[col * lda];
                 sum         = common::Tsqr_add_ru<T>(tmp, sum);
             }
         }
     }
 
-    samax[threadIdx.y][threadIdx.x] = amax;
-    ssum[threadIdx.y][threadIdx.x]  = sum;
+    ssum[threadIdx.y][threadIdx.x] = sum;
     __syncthreads();
 
     sum    = ssum[threadIdx.x][threadIdx.y];
-    vecnrm = common::inner_warp_sum<U, common::TILE_DIM>(sum);
-
-    amax = samax[threadIdx.x][threadIdx.y];
-    return common::inner_warp_max<U, common::TILE_DIM>(amax);
+    return common::inner_warp_sum<U, common::TILE_DIM>(sum);
 }
 
 } // namespace gemmul8::scaling::fast

--- a/src/oz2/scaling/fast/scaling.hpp
+++ b/src/oz2/scaling/fast/scaling.hpp
@@ -19,14 +19,13 @@ __global__ void scaling_colwise(
     int16_t *const __restrict__ sftA //
 ) {
     using U = common::underlying_t<T>;
-    __shared__ U samax[32];
     __shared__ U ssum[32];
 
     const unsigned col_idx         = blockIdx.x;
     const T *const __restrict__ in = A + col_idx * lda;
 
     const int32_t sft = calc_sft_colwise<T, BACKEND, NUM_MODULI, UPLO, DIAG>(
-        rows_A, in, sftA, samax, ssum);
+        rows_A, in, sftA, ssum);
 
     general::scaling_colwise_device<T, BACKEND, NUM_MODULI, UPLO, DIAG, CONJ>(
         rows_A, in, A_lo, lda_lo, incA_lo, sft);
@@ -47,15 +46,11 @@ void scaling(
         if (op_A == CUBLAS_OP_N) {
 
             // A: rows_A x cols_A -> A_lo: cols_A x rows_A
-            using U = common::underlying_t<T>;
-            const unsigned num_col_blocks =
-                (cols_A + rowwise_sft_col_tile - 1U) / rowwise_sft_col_tile;
-
-            U *const partial_amax = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
-            U *const partial_sum  = partial_amax + size_t(rows_A) * num_col_blocks;
+            using U              = common::underlying_t<T>;
+            U *const partial_sum = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
 
             calc_sft_rowwise_launch<T, BACKEND, NUM_MODULI, UPLO, DIAG>(
-                stream, rows_A, cols_A, A, lda, sftA, partial_amax, partial_sum);
+                stream, rows_A, cols_A, A, lda, sftA, partial_sum);
 
             if constexpr (UPLO != CUBLAS_FILL_MODE_FULL) {
                 general::memset_low_mats_async<T, BACKEND, NUM_MODULI>(stream, A_lo, incA_lo);
@@ -100,15 +95,11 @@ void scaling(
         } else {
 
             // A: cols_A x rows_A -> A_lo: rows_A x cols_A
-            using U = common::underlying_t<T>;
-            const unsigned num_col_blocks =
-                (rows_A + rowwise_sft_col_tile - 1U) / rowwise_sft_col_tile;
-
-            U *const partial_amax = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
-            U *const partial_sum  = partial_amax + size_t(cols_A) * num_col_blocks;
+            using U              = common::underlying_t<T>;
+            U *const partial_sum = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
 
             calc_sft_rowwise_launch<T, BACKEND, NUM_MODULI, UPLO, DIAG>(
-                stream, cols_A, rows_A, A, lda, sftA, partial_amax, partial_sum);
+                stream, cols_A, rows_A, A, lda, sftA, partial_sum);
 
             if constexpr (UPLO != CUBLAS_FILL_MODE_FULL) {
                 general::memset_low_mats_async<T, BACKEND, NUM_MODULI>(stream, A_lo, incA_lo);

--- a/src/oz2/scaling/fast/scaling_symm_hemm.hpp
+++ b/src/oz2/scaling/fast/scaling_symm_hemm.hpp
@@ -25,17 +25,15 @@ void scaling_symm_hemm_launch(
 
     using U                    = common::underlying_t<T>;
     const size_t partial_elems = size_t(n) * num_col_blocks;
-    U *const partial_amax      = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
-    U *const partial_sum       = partial_amax + partial_elems;
-    U *const amaxA             = partial_sum + partial_elems;
-    U *const sumA              = amaxA + n;
+    U *const partial_sum       = general::temporary_memory<common::low_t<BACKEND>, U>(A_lo.ptr0);
+    U *const sumA              = partial_sum + partial_elems;
 
     calc_stat_sym_rowwise_launch<T, UPLO, HERM>(
-        stream, n, A, lda, partial_amax, partial_sum, amaxA, sumA);
+        stream, n, A, lda, partial_sum, sumA);
 
     calc_sft_sym_colwise<T, BACKEND, NUM_MODULI, UPLO>
         <<<n, threads_fast, 0, stream>>>(
-            n, A, lda, sftA, amaxA, sumA);
+            n, A, lda, sftA, sumA);
 
     if constexpr (HERM) {
 


### PR DESCRIPTION
This is a change to fast mode scaling based on [arXiv:2606.29129](https://arxiv.org/abs/2606.29129).

The previous fast-mode scaling lacks scale-invariance and could fail CRT reconstruction. 
This implementation uses a scaling formula derived directly from the CRT condition via the Cauchy--Schwarz inequality, so CRT reconstruction never fails and scale-invariance is guaranteed. 
It achieves accuracy comparable to accurate mode at the same throughput as the previous fast mode.

This code is based on [my implementation](https://github.com/kotatsumuri/GEMMul8), revised by @UCHINO-Yuki.
